### PR TITLE
replace string with pl.lit expression in method chaining section

### DIFF
--- a/book/method_chaining.qmd
+++ b/book/method_chaining.qmd
@@ -81,7 +81,7 @@ def time_col_pl(col: str) -> pl.Expr:
     col_expr = pl.col(col)
     return (
         pl.when(col_expr == "2400")
-        .then("0000")
+        .then(pl.lit("0000"))
         .otherwise(col_expr)
         .str.strptime(pl.Time, "%H%M", strict=True)
         .alias(col)


### PR DESCRIPTION
Thanks a lot for your work, I have learned a lot from your book! I have noticed a deprecation error with one of the examples.  

```
DeprecationWarning: in a future version, string input will be parsed as a column name rather than a string literal. To silence this warning, pass the input as an expression instead: `pl.lit('0000')`
  .then("0000")
```

I have replaced the expression accordingly. 

### My current version 

```
--------Version info---------
Polars:              0.18.11
Index type:          UInt32
Platform:            macOS-13.5-arm64-arm-64bit
Python:              3.11.4 (main, Jul 29 2023, 15:59:02) [Clang 14.0.3 (clang-1403.0.22.14.1)]
```