### PR TITLE
Updates Expr.take() to Expr.gather()

### DIFF
--- a/book/indexing.qmd
+++ b/book/indexing.qmd
@@ -100,7 +100,7 @@ Using `head` and `tail`:
 df_pl.select(["Dest", "Tail_Number"]).head(16).tail(4)
 ```
 
-Or using `take`:
+Or using `gather`:
 
 ``` {python}
 df_pl.select(pl.col(["Dest", "Tail_Number"]).gather(list(range(12, 16))))


### PR DESCRIPTION
as per title. 

.take() is deprecated and renamed to .gather()
[polars docs](https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.take.html#polars.Expr.take)